### PR TITLE
more support for cloudinary

### DIFF
--- a/fields/types/cloudinaryimage/CloudinaryImageType.js
+++ b/fields/types/cloudinaryimage/CloudinaryImageType.js
@@ -352,7 +352,7 @@ function trimSupportedFileExtensions (publicId) {
 		'.jpg', '.jpe', '.jpeg', '.jpc', '.jp2', '.j2k', '.wdp', '.jxr',
 		'.hdp', '.png', '.gif', '.webp', '.bmp', '.tif', '.tiff', '.ico',
 		'.pdf', '.ps', '.ept', '.eps', '.eps3', '.psd', '.svg', '.ai',
-		'.djvu', '.flif', '.tga',
+		'.djvu', '.flif', '.tga', 'pdf', '.docx', '.doc'
 	];
 	for (var i = 0; i < supportedExtensions.length; i++) {
 		var extension = supportedExtensions[i];

--- a/fields/types/list/ListField.js
+++ b/fields/types/list/ListField.js
@@ -97,6 +97,7 @@ module.exports = Field.create({
 	renderItems () {
 		const { value = [], path } = this.props;
 		const onAdd = this.addItem;
+		console.log(value, path, this);
 		return (
 			<div>
 				{value.map((value, index) => {

--- a/fields/types/list/ListField.js
+++ b/fields/types/list/ListField.js
@@ -97,7 +97,6 @@ module.exports = Field.create({
 	renderItems () {
 		const { value = [], path } = this.props;
 		const onAdd = this.addItem;
-		console.log(value, path, this);
 		return (
 			<div>
 				{value.map((value, index) => {

--- a/fields/types/list/ListType.js
+++ b/fields/types/list/ListType.js
@@ -74,8 +74,6 @@ list.prototype.addToSchema = function (schema) {
 				+ 'Did you misspell the field type?\n'
 			);
 		}
-		console.log('###############');
-		console.log(field, options.type);
 		options.type = validateFieldType(field, path, options.type);
 		// We need to tell the Keystone List that this field type is in use
 		field.list.fieldTypes[options.type.name] = options.type.properName;


### PR DESCRIPTION
<!--

 Please make sure the following is filled in before submitting your Pull Request - thanks!

 -->

## Description of changes



## Related issues (if any)


## Testing

- [ ] Please confirm `npm run test-all` ran successfully.

<!--

 Notes:

 * To successfully have all e2e tests pass you need to have the following setup:
    - a recent version of the chrome browser
    - java 1.8+
 * If you are developing in Windows you may run into linebreak linting issues.
   One possible workaround is to remove the "linebreak-style" rule in `node_modules/eslint-config-keystone/eslintrc.json`.

 -->

